### PR TITLE
Update index property

### DIFF
--- a/discover/deployment/articles/03-maintaining-liferay/03-upgrading-liferay.markdown
+++ b/discover/deployment/articles/03-maintaining-liferay/03-upgrading-liferay.markdown
@@ -36,10 +36,10 @@ Call that file `com.liferay.portal.store.file.system.configuration.AdvancedFileS
 if you use this method to persist the document library files.
 
 To upgrade your portal to Liferay 7, you should create a file called
-`com.liferay.portal.search.configuration.IndexWriterHelperConfiguration.cfg` in
+`com.liferay.portal.search.configuration.IndexStatusManagerConfiguration.cfg` in
 your `[Liferay Home]/osgi/configs` folder with this contents:
 
-    index.read.only=true
+    indexReadOnly=true
 
 Setting the property above disables indexing. By disabling indexing, you avoid
 the possibility of faulty indexing and you save time during the upgrade


### PR DESCRIPTION
Hey Alberto,

There has been some confusion about the property used to set the index to read-only for upgrading.

According to @arboliveira the property has been moved. This was found while testing a bug ticket (See [LPS-64975](https://issues.liferay.com/browse/LPS-64975)).

Since QA started testing with the new property, at least one major bug was found (See [LPS-65253](https://issues.liferay.com/browse/LPS-65253)). Because the documentation shows the old property, the developer working on this was having difficulty reproducing. I am sending you this update to your new doc on the upgrade tool to help clear up the confusion.

Please let me know if you have any questions. Thanks!

CC @jrhoun @mdelapenya